### PR TITLE
Add GetMetrics

### DIFF
--- a/states/states.go
+++ b/states/states.go
@@ -51,7 +51,9 @@ func (s *cmdState) Process(cmd string) (State, error) {
 		if _, ok := s.nextState.(*exitState); ok {
 			return s.nextState, ExitErr
 		}
-		return s.nextState, nil
+		nextState := s.nextState
+		s.nextState = nil
+		return nextState, nil
 	}
 	// clean up args
 	s.rootCmd.SetArgs(nil)

--- a/states/visit.go
+++ b/states/visit.go
@@ -2,15 +2,32 @@ package states
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
 
+	"github.com/congqixia/birdwatcher/models"
+	"github.com/congqixia/birdwatcher/proto/v2.0/datapb"
+	"github.com/congqixia/birdwatcher/proto/v2.0/indexpb"
 	"github.com/congqixia/birdwatcher/proto/v2.0/querypb"
+	"github.com/congqixia/birdwatcher/proto/v2.0/rootcoordpb"
 	"github.com/spf13/cobra"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/grpc"
 )
+
+func getSessionTypes() []string {
+	return []string{
+		"datacoord",
+		"datanode",
+		"indexcoord",
+		"indexnode",
+		"querycoord",
+		"querynode",
+		"rootcoord",
+	}
+}
 
 func getVisitCmd(state State, cli *clientv3.Client, basePath string) *cobra.Command {
 	callCmd := &cobra.Command{
@@ -19,17 +36,71 @@ func getVisitCmd(state State, cli *clientv3.Client, basePath string) *cobra.Comm
 	}
 
 	callCmd.AddCommand(
-		getVisitQueryNodeCmd(state, cli, basePath),
+		getVisitSessionCmds(state, cli, basePath)...,
 	)
 
 	return callCmd
 }
 
-func getVisitQueryNodeCmd(state State, cli *clientv3.Client, basePath string) *cobra.Command {
-	callQNCmd := &cobra.Command{
-		Use:   "querynode {nodeid}",
-		Short: "components of querynodes",
-		Run: func(cmd *cobra.Command, args []string) {
+func setNextState(sessionType string, conn *grpc.ClientConn, statePtr *State, session *models.Session) {
+	state := *statePtr
+	switch sessionType {
+	case "datacoord":
+		client := datapb.NewDataCoordClient(conn)
+		state.SetNext(getDataCoordState(client, conn, state, session))
+	case "datanode":
+		client := datapb.NewDataNodeClient(conn)
+		state.SetNext(getDataNodeState(client, conn, state, session))
+	case "indexcoord":
+		client := indexpb.NewIndexCoordClient(conn)
+		state.SetNext(getIndexCoordState(client, conn, state, session))
+	case "indexnode":
+		client := indexpb.NewIndexNodeClient(conn)
+		state.SetNext(getIndexNodeState(client, conn, state, session))
+	case "querycoord":
+		client := querypb.NewQueryCoordClient(conn)
+		state.SetNext(getQueryCoordState(client, conn, state, session))
+	case "querynode":
+		client := querypb.NewQueryNodeClient(conn)
+		state.SetNext(getQueryNodeState(client, conn, state, session))
+	case "rootcoord":
+		client := rootcoordpb.NewRootCoordClient(conn)
+		state.SetNext(getRootCoordState(client, conn, state, session))
+	}
+}
+
+func getSessionConnect(cli *clientv3.Client, basePath string, id int64, sessionType string) (session *models.Session, conn *grpc.ClientConn, err error) {
+	sessions, err := listSessions(cli, basePath)
+	if err != nil {
+		fmt.Println("failed to list session, err:", err.Error())
+		return nil, nil, err
+	}
+
+	for _, session := range sessions {
+		if id == session.ServerID && session.ServerName == sessionType {
+			opts := []grpc.DialOption{
+				grpc.WithInsecure(),
+				grpc.WithBlock(),
+				grpc.WithTimeout(2 * time.Second),
+			}
+
+			conn, err = grpc.DialContext(context.Background(), session.Address, opts...)
+			if err != nil {
+				fmt.Printf("failed to connect to proxy(%d) addr: %s, err: %s\n", session.ServerID, session.Address, err.Error())
+			}
+			return session, conn, err
+		}
+	}
+
+	fmt.Printf("%s id:%d not found\n", sessionType, id)
+	return nil, nil, errors.New("invalid id")
+}
+func getVisitSessionCmds(state State, cli *clientv3.Client, basePath string) []*cobra.Command {
+	sessionCmds := make([]*cobra.Command, 0, len(getSessionTypes()))
+	sessionTypes := getSessionTypes()
+
+	RunFuncFactory := func(sessionType string) func(cmd *cobra.Command, args []string) {
+		return func(cmd *cobra.Command, args []string) {
 			if len(args) < 1 {
 				cmd.Usage()
 				return
@@ -39,35 +110,21 @@ func getVisitQueryNodeCmd(state State, cli *clientv3.Client, basePath string) *c
 				cmd.Usage()
 				return
 			}
-			sessions, err := listSessions(cli, basePath)
+			session, conn, err := getSessionConnect(cli, basePath, id, sessionType)
 			if err != nil {
-				fmt.Println("failed to list session, err:", err.Error())
 				return
 			}
-
-			for _, session := range sessions {
-				if id == session.ServerID && session.ServerName == "querynode" {
-					//client :=
-					opts := []grpc.DialOption{
-						grpc.WithInsecure(),
-						grpc.WithBlock(),
-						grpc.WithTimeout(2 * time.Second),
-					}
-
-					conn, err := grpc.DialContext(context.Background(), session.Address, opts...)
-					if err != nil {
-						fmt.Printf("failed to connect to proxy(%d) addr: %s, err: %s\n", id, session.Address, err.Error())
-					}
-
-					client := querypb.NewQueryNodeClient(conn)
-					state.SetNext(getQueryNodeState(client, conn, state, session))
-					return
-				}
-			}
-
-			fmt.Printf("querynode id:%d not found\n", id)
-		},
+			setNextState(sessionType, conn, &state, session)
+		}
 	}
 
-	return callQNCmd
+	for i := 0; i < len(sessionTypes); i++ {
+		callCmd := &cobra.Command{
+			Use:   sessionTypes[i] + " {serverId}",
+			Short: "component of " + sessionTypes[i] + "s",
+			Run:   RunFuncFactory(sessionTypes[i]),
+		}
+		sessionCmds = append(sessionCmds, callCmd)
+	}
+	return sessionCmds
 }

--- a/states/visit_datacoord.go
+++ b/states/visit_datacoord.go
@@ -1,0 +1,61 @@
+package states
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/congqixia/birdwatcher/models"
+	"github.com/congqixia/birdwatcher/proto/v2.0/datapb"
+	"github.com/congqixia/birdwatcher/proto/v2.0/milvuspb"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+type dataCoordState struct {
+	cmdState
+	client    datapb.DataCoordClient
+	conn      *grpc.ClientConn
+	prevState State
+}
+
+func getDataCoordState(client datapb.DataCoordClient, conn *grpc.ClientConn, prev State, session *models.Session) State {
+	cmd := &cobra.Command{}
+
+	state := &dataCoordState{
+		cmdState: cmdState{
+			label:   fmt.Sprintf("DataCoord-%d(%s)", session.ServerID, session.Address),
+			rootCmd: cmd,
+		},
+		client: client,
+		conn:   conn,
+	}
+
+	cmd.AddCommand(
+		//GetMetrics
+		getDataCoordMetrics(client),
+		//back
+		getBackCmd(state, prev),
+		// exit
+		getExitCmd(state),
+	)
+	return state
+}
+
+func getDataCoordMetrics(client datapb.DataCoordClient) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "GetMetrics",
+		Short: "show the metrics provided by this datacoord",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			resp, err := client.GetMetrics(context.Background(), &milvuspb.GetMetricsRequest{
+				Request: `{"metric_type": "system_info"}`,
+			})
+			if err != nil {
+				fmt.Println(err.Error())
+				return
+			}
+			fmt.Printf("Metrics: %#v\n", resp.Response)
+		},
+	}
+	return cmd
+}

--- a/states/visit_datanode.go
+++ b/states/visit_datanode.go
@@ -1,0 +1,61 @@
+package states
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/congqixia/birdwatcher/models"
+	"github.com/congqixia/birdwatcher/proto/v2.0/datapb"
+	"github.com/congqixia/birdwatcher/proto/v2.0/milvuspb"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+type dataNodeState struct {
+	cmdState
+	client    datapb.DataNodeClient
+	conn      *grpc.ClientConn
+	prevState State
+}
+
+func getDataNodeState(client datapb.DataNodeClient, conn *grpc.ClientConn, prev State, session *models.Session) State {
+	cmd := &cobra.Command{}
+
+	state := &dataNodeState{
+		cmdState: cmdState{
+			label:   fmt.Sprintf("DataNode-%d(%s)", session.ServerID, session.Address),
+			rootCmd: cmd,
+		},
+		client: client,
+		conn:   conn,
+	}
+
+	cmd.AddCommand(
+		//GetMetrics
+		getDataNodeMetrics(client),
+		//back
+		getBackCmd(state, prev),
+		// exit
+		getExitCmd(state),
+	)
+	return state
+}
+
+func getDataNodeMetrics(client datapb.DataNodeClient) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "GetMetrics",
+		Short: "show the metrics provided by this datanode",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			resp, err := client.GetMetrics(context.Background(), &milvuspb.GetMetricsRequest{
+				Request: `{"metric_type": "system_info"}`,
+			})
+			if err != nil {
+				fmt.Println(err.Error())
+				return
+			}
+			fmt.Printf("Metrics: %#v\n", resp.Response)
+		},
+	}
+	return cmd
+}

--- a/states/visit_indexcoord.go
+++ b/states/visit_indexcoord.go
@@ -1,0 +1,61 @@
+package states
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/congqixia/birdwatcher/models"
+	"github.com/congqixia/birdwatcher/proto/v2.0/indexpb"
+	"github.com/congqixia/birdwatcher/proto/v2.0/milvuspb"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+type indexCoordState struct {
+	cmdState
+	client    indexpb.IndexCoordClient
+	conn      *grpc.ClientConn
+	prevState State
+}
+
+func getIndexCoordState(client indexpb.IndexCoordClient, conn *grpc.ClientConn, prev State, session *models.Session) State {
+	cmd := &cobra.Command{}
+
+	state := &indexCoordState{
+		cmdState: cmdState{
+			label:   fmt.Sprintf("IndexCoord-%d(%s)", session.ServerID, session.Address),
+			rootCmd: cmd,
+		},
+		client: client,
+		conn:   conn,
+	}
+
+	cmd.AddCommand(
+		//GetMetrics
+		getIndexCoordMetrics(client),
+		//back
+		getBackCmd(state, prev),
+		// exit
+		getExitCmd(state),
+	)
+	return state
+}
+
+func getIndexCoordMetrics(client indexpb.IndexCoordClient) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "GetMetrics",
+		Short: "show the metrics provided by this indexcoord",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			resp, err := client.GetMetrics(context.Background(), &milvuspb.GetMetricsRequest{
+				Request: `{"metric_type": "system_info"}`,
+			})
+			if err != nil {
+				fmt.Println(err.Error())
+				return
+			}
+			fmt.Printf("Metrics: %#v\n", resp.Response)
+		},
+	}
+	return cmd
+}

--- a/states/visit_indexnode.go
+++ b/states/visit_indexnode.go
@@ -1,0 +1,61 @@
+package states
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/congqixia/birdwatcher/models"
+	"github.com/congqixia/birdwatcher/proto/v2.0/indexpb"
+	"github.com/congqixia/birdwatcher/proto/v2.0/milvuspb"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+type indexNodeState struct {
+	cmdState
+	client    indexpb.IndexNodeClient
+	conn      *grpc.ClientConn
+	prevState State
+}
+
+func getIndexNodeState(client indexpb.IndexNodeClient, conn *grpc.ClientConn, prev State, session *models.Session) State {
+	cmd := &cobra.Command{}
+
+	state := &indexNodeState{
+		cmdState: cmdState{
+			label:   fmt.Sprintf("IndexNode-%d(%s)", session.ServerID, session.Address),
+			rootCmd: cmd,
+		},
+		client: client,
+		conn:   conn,
+	}
+
+	cmd.AddCommand(
+		//GetMetrics
+		getIndexNodeMetrics(client),
+		//back
+		getBackCmd(state, prev),
+		// exit
+		getExitCmd(state),
+	)
+	return state
+}
+
+func getIndexNodeMetrics(client indexpb.IndexNodeClient) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "GetMetrics",
+		Short: "show the metrics provided by this indexnode",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			resp, err := client.GetMetrics(context.Background(), &milvuspb.GetMetricsRequest{
+				Request: `{"metric_type": "system_info"}`,
+			})
+			if err != nil {
+				fmt.Println(err.Error())
+				return
+			}
+			fmt.Printf("Metrics: %#v\n", resp.Response)
+		},
+	}
+	return cmd
+}

--- a/states/visit_querycoord.go
+++ b/states/visit_querycoord.go
@@ -1,0 +1,61 @@
+package states
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/congqixia/birdwatcher/models"
+	"github.com/congqixia/birdwatcher/proto/v2.0/milvuspb"
+	"github.com/congqixia/birdwatcher/proto/v2.0/querypb"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+type queryCoordState struct {
+	cmdState
+	client    querypb.QueryCoordClient
+	conn      *grpc.ClientConn
+	prevState State
+}
+
+func getQueryCoordState(client querypb.QueryCoordClient, conn *grpc.ClientConn, prev State, session *models.Session) State {
+	cmd := &cobra.Command{}
+
+	state := &queryCoordState{
+		cmdState: cmdState{
+			label:   fmt.Sprintf("QueryCoord-%d(%s)", session.ServerID, session.Address),
+			rootCmd: cmd,
+		},
+		client: client,
+		conn:   conn,
+	}
+
+	cmd.AddCommand(
+		//GetMetrics
+		getQueryCoordMetrics(client),
+		//back
+		getBackCmd(state, prev),
+		// exit
+		getExitCmd(state),
+	)
+	return state
+}
+
+func getQueryCoordMetrics(client querypb.QueryCoordClient) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "GetMetrics",
+		Short: "show the metrics provided by this querycoord",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			resp, err := client.GetMetrics(context.Background(), &milvuspb.GetMetricsRequest{
+				Request: `{"metric_type": "system_info"}`,
+			})
+			if err != nil {
+				fmt.Println(err.Error())
+				return
+			}
+			fmt.Printf("Metrics: %#v\n", resp.Response)
+		},
+	}
+	return cmd
+}

--- a/states/visit_rootcoord.go
+++ b/states/visit_rootcoord.go
@@ -1,0 +1,61 @@
+package states
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/congqixia/birdwatcher/models"
+	"github.com/congqixia/birdwatcher/proto/v2.0/milvuspb"
+	"github.com/congqixia/birdwatcher/proto/v2.0/rootcoordpb"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+type rootCoordState struct {
+	cmdState
+	client    rootcoordpb.RootCoordClient
+	conn      *grpc.ClientConn
+	prevState State
+}
+
+func getRootCoordState(client rootcoordpb.RootCoordClient, conn *grpc.ClientConn, prev State, session *models.Session) State {
+	cmd := &cobra.Command{}
+
+	state := &rootCoordState{
+		cmdState: cmdState{
+			label:   fmt.Sprintf("RootCoord-%d(%s)", session.ServerID, session.Address),
+			rootCmd: cmd,
+		},
+		client: client,
+		conn:   conn,
+	}
+
+	cmd.AddCommand(
+		//GetMetrics
+		getRootCoordMetrics(client),
+		//back
+		getBackCmd(state, prev),
+		// exit
+		getExitCmd(state),
+	)
+	return state
+}
+
+func getRootCoordMetrics(client rootcoordpb.RootCoordClient) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "GetMetrics",
+		Short: "show the metrics provided by this rootcoord",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			resp, err := client.GetMetrics(context.Background(), &milvuspb.GetMetricsRequest{
+				Request: `{"metric_type": "system_info"}`,
+			})
+			if err != nil {
+				fmt.Println(err.Error())
+				return
+			}
+			fmt.Printf("Metrics: %#v\n", resp.Response)
+		},
+	}
+	return cmd
+}


### PR DESCRIPTION
Clear the nextState as app go to next state to prevent some bugs that occur after the app back to last state.
Add datacoord, datanode, indexcoord, indexnode, querycoord,rootcoord to the visit cmd as an alternative session types.
Add Cmd GetMetrics for all alternative session types.